### PR TITLE
Dynamic materialized/drupal view

### DIFF
--- a/includes/tripal_phylotree_userinfo_block.inc
+++ b/includes/tripal_phylotree_userinfo_block.inc
@@ -1,10 +1,10 @@
 <?php
 
 /**
- *@ Userinfo block and content: 
+ *@ Userinfo block and content:
  *  A block (with guide text) at the top of module view with an optional link to detailed help in another drupal path.
  *  The detailed help drupal path is defined here via altering hook_menu and contents populated by a template by altering hook_theme.
- *  These routines avoid embedding any code inside the hook_menu and hook_theme in the .module file.  
+ *  These routines avoid embedding any code inside the hook_menu and hook_theme in the .module file.
  *  Hence can stay independent of the main module code.
  */
 
@@ -16,7 +16,7 @@ function tripal_phylotree_block_info() {
   $blocks['tripal_phylotree_userinfo_block'] = array(  //the block-id (prefix with module name to avoid namespace conflict)
     'info' => t('User info block at top of tripal_phylotree view.'),
     'status' => TRUE,
-    'region' => 'highlighted', 
+    'region' => 'highlighted',
     'weight' => 0,
     'visibility' => BLOCK_VISIBILITY_LISTED, // appears only in listed paths
     'pages' => "search/phylotree", // block appears only in this path
@@ -27,11 +27,11 @@ function tripal_phylotree_block_info() {
 
 /**
  * Implements hook_block_view().
- *   The block content 
+ *   The block content
  */
 function tripal_phylotree_block_view($delta='') {
   $block = array();
-  switch ($delta) { 
+  switch ($delta) {
     case 'tripal_phylotree_userinfo_block':  //if this is the block-ID
       //a heading
       $block['subject'] = t('<span align="center" style="font-size:100%">Phylotree: Gene Family Search</span>');
@@ -44,7 +44,7 @@ function tripal_phylotree_block_view($delta='') {
 
 
 /**
-  * the userinfo block content 
+  * the userinfo block content
   * return string
   */
 function tripal_phylotree_userinfo_block_contents() {
@@ -71,7 +71,7 @@ function tripal_phylotree_menu_alter(&$items) {
 function tripal_phylotree_theme_registry_alter(&$theme_registry) {
 //Userinfo template
     // Very Imp that you declare the module path here. Path works differently in hook_theme vs. hook_theme_registry_alter
-    $module_path = drupal_get_path('module', 'tripal_phylotree'); 
+    $module_path = drupal_get_path('module', 'tripal_phylotree');
     $theme_registry['tripal_phylotree_userinfo'] = array(
       'variables' => array('node' => NULL),
       'template' => 'tripal_phylotree_userinfo',
@@ -86,6 +86,3 @@ function userinfo_content() {
 }
 
 /* End: The detailed help path with contents  */
-
-
-

--- a/includes/views/handlers/tripal_phylotree.handler.inc
+++ b/includes/views/handlers/tripal_phylotree.handler.inc
@@ -1,0 +1,54 @@
+<?php
+class tripal_phylotree_views_handler_field_org_count extends views_handler_field {
+  function render($values) {
+    $counts_by_org = $this->options['counts_by_org'];
+    $tokens = $this->get_render_tokens('');
+    if(!empty($tokens)) {
+      $counts_by_org = $tokens[$counts_by_org];
+
+      $by_orgs_raw = json_decode(html_entity_decode($counts_by_org));
+      $by_orgs = array();
+      foreach ($by_orgs_raw as $value) {
+        // Using array_merge() is tempting, but it will make array keys unusable https://stackoverflow.com/a/35180513
+        foreach ($value as $key => $value2) {
+          $by_orgs[$key] = $value2;
+        }
+      }
+
+      $org_id = substr($this->options['id'], 0, -6);
+
+      if (isset($by_orgs[$org_id])) {
+        return $by_orgs[$org_id];
+      }
+    }
+    return 0;
+  }
+
+  function option_definition() {
+    $options = parent::option_definition();
+    //define our custom settings fields
+    $options['counts_by_org'] = array();
+    return $options;
+  }
+
+  function options_form(&$form, &$form_state) {
+    $options = array();
+    foreach ($this->view->display_handler->get_handlers('field') as $field => $handler) {
+      $options[t('Fields')]["[$field]"] = $handler->ui_name();
+    }
+    $form['counts_by_org'] = array(
+      '#type' => 'select',
+      '#title' => t('Count by orgs'),
+      '#options' => $options,
+      '#default_value' => isset($this->options['counts_by_org']) ? $this->options['counts_by_org'] : '',
+      '#required' => TRUE
+    );
+    parent::options_form($form, $form_state);
+  }
+
+  function options_submit(&$form, &$form_state) {
+    parent::options_submit($form, $form_state);
+    //update our custom values
+    $this->options['counts_by_org'] = $form_state['values']['options']['counts_by_org'];
+  }
+}

--- a/includes/views/tripal_phylotree.views.inc
+++ b/includes/views/tripal_phylotree.views.inc
@@ -4,6 +4,8 @@
  * Describe default phylotree views
  */
 
+require_once 'handlers/tripal_phylotree.handler.inc';
+
 /**
  * Implements hook_views_default_views().
  *
@@ -15,7 +17,7 @@ function tripal_phylotree_views_default_views() {
     // User View ("Search Biological Content") Remember, if you change
     // the name/path of this view, you also want to change it's
     // description in tripal_phylotree_search_biological_data_views()
-  
+
     $view = tripal_phylotree_defaultvalue_user_phylotrees();
     $view = tripal_make_view_compatible_with_external($view);
     $views[$view->name] = $view;
@@ -24,7 +26,7 @@ function tripal_phylotree_views_default_views() {
     //$view = tripal_phylotree_defaultview_admin_phylotrees();
     //$view = tripal_make_view_compatible_with_external($view);
     //$views[$view->name] = $view;
-  
+
     return $views;
 }
 
@@ -42,46 +44,36 @@ function tripal_phylotree_defaultvalue_user_phylotrees() {
    $args = array(':name' => 'polypeptide_domain');
    $result = chado_query($sql_count, $args)->fetchObject();
 
-    $view = new view();
-    $view->name = 'phylotree';
-    $view->description = '';
-    $view->tag = 'default';
-    $view->base_table = 'phylotree_count';
-    $view->human_name = 'Phylotree';
-    $view->core = 7;
-    $view->api_version = '3.0';
-    $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+   $view = new view();
+   $view->name = 'phylotree';
+   $view->description = '';
+   $view->tag = 'default';
+   $view->base_table = 'phylotree_count';
+   $view->human_name = 'Phylotree';
+   $view->core = 7;
+   $view->api_version = '3.0';
+   $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
 
-    /* Display: Master */
-    $handler = $view->new_display('default', 'Master', 'default');
-    $handler->display->display_options['title'] = 'Phylotree';
-    $handler->display->display_options['use_more_always'] = FALSE;
-    $handler->display->display_options['access']['type'] = 'none';
-    $handler->display->display_options['cache']['type'] = 'none';
-    $handler->display->display_options['query']['type'] = 'views_query';
-    $handler->display->display_options['exposed_form']['type'] = 'basic';
-    $handler->display->display_options['exposed_form']['options']['reset_button'] = TRUE;
-    $handler->display->display_options['pager']['type'] = 'full';
-    $handler->display->display_options['pager']['options']['items_per_page'] = '10';
-    $handler->display->display_options['style_plugin'] = 'table';
-    $handler->display->display_options['style_options']['columns'] = array(
-        'phylotree_name' => 'phylotree_name',
-        'phylotree_comment' => 'phylotree_comment',
-        'total_count' => 'total_count',
-        'medtr_count' => 'medtr_count',
-        'tripr_count' => 'tripr_count',
-        'lotja_count' => 'lotja_count',
-        'cicar_count' => 'cicar_count',
-        'glyma_count' => 'glyma_count',
-        'phavu_count' => 'phavu_count',
-        'cajca_count' => 'cajca_count',
-        'vigun_count' => 'vigun_count',
-        'vigra_count' => 'vigra_count',
-        'vigan_count' => 'vigan_count',
-        'aradu_count' => 'aradu_count',
-        'araip_count' => 'araip_count',
-        'lupan_count' => 'lupan_count',
-    );
+   /* Display: Master */
+   $handler = $view->new_display('default', 'Master', 'default');
+   $handler->display->display_options['title'] = 'Phylotree';
+   $handler->display->display_options['use_more_always'] = FALSE;
+   $handler->display->display_options['access']['type'] = 'none';
+   $handler->display->display_options['cache']['type'] = 'none';
+   $handler->display->display_options['query']['type'] = 'views_query';
+   $handler->display->display_options['exposed_form']['type'] = 'basic';
+   $handler->display->display_options['exposed_form']['options']['reset_button'] = TRUE;
+   $handler->display->display_options['pager']['type'] = 'full';
+   $handler->display->display_options['pager']['options']['items_per_page'] = '10';
+   $handler->display->display_options['style_plugin'] = 'table';
+   $handler->display->display_options['style_options']['columns'] = array(
+     'phylotree_name' => 'phylotree_name',
+     'phylotree_comment' => 'phylotree_comment',
+     'total_count' => 'total_count',
+  );
+
+  $organisms = tripal_phylotree_get_orgs();
+
     $handler->display->display_options['style_options']['default'] = '-1';
     $handler->display->display_options['style_options']['info'] = array(
         'phylotree_name' => array(
@@ -105,98 +97,8 @@ function tripal_phylotree_defaultvalue_user_phylotrees() {
             'separator' => '',
             'empty_column' => 0,
         ),
-        'medtr_count' => array(
-            'sortable' => 1,
-            'default_sort_order' => 'asc',
-            'align' => '',
-            'separator' => '',
-            'empty_column' => 0,
-        ),
-        'tripr_count' => array(
-            'sortable' => 1,
-            'default_sort_order' => 'asc',
-            'align' => '',
-            'separator' => '',
-            'empty_column' => 0,
-        ),
-        'lotja_count' => array(
-            'sortable' => 1,
-            'default_sort_order' => 'asc',
-            'align' => '',
-            'separator' => '',
-            'empty_column' => 0,
-        ),
-        'glyma_count' => array(
-            'sortable' => 1,
-            'default_sort_order' => 'asc',
-            'align' => '',
-            'separator' => '',
-            'empty_column' => 0,
-        ),
-        'phavu_count' => array(
-            'sortable' => 1,
-            'default_sort_order' => 'asc',
-            'align' => '',
-            'separator' => '',
-            'empty_column' => 0,
-        ),
-        'aradu_count' => array(
-            'sortable' => 1,
-            'default_sort_order' => 'asc',
-            'align' => '',
-            'separator' => '',
-            'empty_column' => 0,
-        ),
-        'araip_count' => array(
-            'sortable' => 1,
-            'default_sort_order' => 'asc',
-            'align' => '',
-            'separator' => '',
-            'empty_column' => 0,
-        ),
-        'lupan_count' => array(
-            'sortable' => 1,
-            'default_sort_order' => 'asc',
-            'align' => '',
-            'separator' => '',
-            'empty_column' => 0,
-        ),
-        'cajca_count' => array(
-            'sortable' => 1,
-            'default_sort_order' => 'asc',
-            'align' => '',
-            'separator' => '',
-            'empty_column' => 0,
-        ),
-        'vigun_count' => array(
-            'sortable' => 1,
-            'default_sort_order' => 'asc',
-            'align' => '',
-            'separator' => '',
-            'empty_column' => 0,
-        ),
-        'vigra_count' => array(
-            'sortable' => 1,
-            'default_sort_order' => 'asc',
-            'align' => '',
-            'separator' => '',
-            'empty_column' => 0,
-        ),
-        'vigan_count' => array(
-            'sortable' => 1,
-            'default_sort_order' => 'asc',
-            'align' => '',
-            'separator' => '',
-            'empty_column' => 0,
-        ),
-        'cicar_count' => array(
-            'sortable' => 1,
-            'default_sort_order' => 'asc',
-            'align' => '',
-            'separator' => '',
-            'empty_column' => 0,
-        ),
     );
+
     /* Footer: Global: Result summary */
     $handler->display->display_options['footer']['result']['id'] = 'result';
     $handler->display->display_options['footer']['result']['table'] = 'views';
@@ -223,12 +125,11 @@ function tripal_phylotree_defaultvalue_user_phylotrees() {
     $handler->display->display_options['fields']['phylotree_comment']['field'] = 'phylotree_comment';
     if ($result->count > 0) {
         /* Field: phylotree_count: Domains/Interpro term */
-        
         $handler->display->display_options['fields']['domains']['id'] = 'domains';
         $handler->display->display_options['fields']['domains']['table'] = 'phylotree_count';
         $handler->display->display_options['fields']['domains']['field'] = 'domains';
         $handler->display->display_options['fields']['domains']['exclude'] = TRUE;
-       
+
        /*Field: phylotree_count: Domains/Interpro terms for family consensus */
         $handler->display->display_options['fields']['domains_con']['id'] = 'domains_con';
         $handler->display->display_options['fields']['domains_con']['table'] = 'phylotree_count';
@@ -242,92 +143,12 @@ function tripal_phylotree_defaultvalue_user_phylotrees() {
     $handler->display->display_options['fields']['total_count']['field'] = 'total_count';
     $handler->display->display_options['fields']['total_count']['alter']['make_link'] = TRUE;
     $handler->display->display_options['fields']['total_count']['alter']['path'] = 'search/gene?gene_family=[phylotree_name]';
-    /* Field: phylotree_count: Medtr count */
-    $handler->display->display_options['fields']['medtr_count']['id'] = 'medtr_count';
-    $handler->display->display_options['fields']['medtr_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['fields']['medtr_count']['field'] = 'medtr_count';
-    $handler->display->display_options['fields']['medtr_count']['alter']['make_link'] = TRUE;
-    $handler->display->display_options['fields']['medtr_count']['alter']['path'] = 'search/gene?gene_family=[phylotree_name]&abbreviation=medtr';
-    $handler->display->display_options['fields']['medtr_count']['alter']['absolute'] = TRUE;
-    /* Field: phylotree_count: Tripr count */
-    $handler->display->display_options['fields']['tripr_count']['id'] = 'tripr_count';
-    $handler->display->display_options['fields']['tripr_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['fields']['tripr_count']['field'] = 'tripr_count';
-    $handler->display->display_options['fields']['tripr_count']['alter']['make_link'] = TRUE;
-    $handler->display->display_options['fields']['tripr_count']['alter']['path'] = 'search/gene?gene_family=[phylotree_name]&abbreviation=tripr';
-    $handler->display->display_options['fields']['tripr_count']['alter']['absolute'] = TRUE;
-    /* Field: phylotree_count: Lotja count */
-    $handler->display->display_options['fields']['lotja_count']['id'] = 'lotja_count';
-    $handler->display->display_options['fields']['lotja_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['fields']['lotja_count']['field'] = 'lotja_count';
-    $handler->display->display_options['fields']['lotja_count']['alter']['make_link'] = TRUE;
-    $handler->display->display_options['fields']['lotja_count']['alter']['path'] = 'search/gene?gene_family=[phylotree_name]&abbreviation=lotja';
-    $handler->display->display_options['fields']['lotja_count']['alter']['absolute'] = TRUE;
-    /* Field: phylotree_count: Cicar count */
-    $handler->display->display_options['fields']['cicar_count']['id'] = 'cicar_count';
-    $handler->display->display_options['fields']['cicar_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['fields']['cicar_count']['field'] = 'cicar_count';
-    $handler->display->display_options['fields']['cicar_count']['alter']['make_link'] = TRUE;
-    $handler->display->display_options['fields']['cicar_count']['alter']['path'] = 'search/gene?gene_family=[phylotree_name]&abbreviation=cicar.CDCFrontier';
-    $handler->display->display_options['fields']['cicar_count']['alter']['absolute'] = TRUE;
-    /* Field: phylotree_count: Glyma count */
-    $handler->display->display_options['fields']['glyma_count']['id'] = 'glyma_count';
-    $handler->display->display_options['fields']['glyma_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['fields']['glyma_count']['field'] = 'glyma_count';
-    $handler->display->display_options['fields']['glyma_count']['alter']['make_link'] = TRUE;
-    $handler->display->display_options['fields']['glyma_count']['alter']['path'] = 'search/gene?gene_family=[phylotree_name]&abbreviation=glyma';
-    $handler->display->display_options['fields']['glyma_count']['alter']['absolute'] = TRUE;
-    /* Field: phylotree_count: Phavu count */
-    $handler->display->display_options['fields']['phavu_count']['id'] = 'phavu_count';
-    $handler->display->display_options['fields']['phavu_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['fields']['phavu_count']['field'] = 'phavu_count';
-    $handler->display->display_options['fields']['phavu_count']['alter']['make_link'] = TRUE;
-    $handler->display->display_options['fields']['phavu_count']['alter']['path'] = 'search/gene?gene_family=[phylotree_name]&abbreviation=phavu';
-    /* Field: phylotree_count: Cajca count */
-    $handler->display->display_options['fields']['cajca_count']['id'] = 'cajca_count';
-    $handler->display->display_options['fields']['cajca_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['fields']['cajca_count']['field'] = 'cajca_count';
-    $handler->display->display_options['fields']['cajca_count']['alter']['make_link'] = TRUE;
-    $handler->display->display_options['fields']['cajca_count']['alter']['path'] = 'search/gene?gene_family=[phylotree_name]&abbreviation=cajca';
-    /* Field: phylotree_count: Vigun count */
-    $handler->display->display_options['fields']['vigun_count']['id'] = 'vigun_count';
-    $handler->display->display_options['fields']['vigun_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['fields']['vigun_count']['field'] = 'vigun_count';
-    $handler->display->display_options['fields']['vigun_count']['alter']['make_link'] = TRUE;
-    $handler->display->display_options['fields']['vigun_count']['alter']['path'] = 'search/gene?gene_family=[phylotree_name]&abbreviation=vigun';
-    /* Field: phylotree_count: Vigra count */
-    $handler->display->display_options['fields']['vigra_count']['id'] = 'vigra_count';
-    $handler->display->display_options['fields']['vigra_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['fields']['vigra_count']['field'] = 'vigra_count';
-    $handler->display->display_options['fields']['vigra_count']['alter']['make_link'] = TRUE;
-    $handler->display->display_options['fields']['vigra_count']['alter']['path'] = 'search/gene?gene_family=[phylotree_name]&abbreviation=vigra';
-    /* Field: phylotree_count: Vigan count */
-    $handler->display->display_options['fields']['vigan_count']['id'] = 'vigan_count';
-    $handler->display->display_options['fields']['vigan_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['fields']['vigan_count']['field'] = 'vigan_count';
-    $handler->display->display_options['fields']['vigan_count']['alter']['make_link'] = TRUE;
-    $handler->display->display_options['fields']['vigan_count']['alter']['path'] = 'search/gene?gene_family=[phylotree_name]&abbreviation=vigan';
-    /* Field: phylotree_count: Aradu count */
-    $handler->display->display_options['fields']['aradu_count']['id'] = 'aradu_count';
-    $handler->display->display_options['fields']['aradu_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['fields']['aradu_count']['field'] = 'aradu_count';
-    $handler->display->display_options['fields']['aradu_count']['alter']['make_link'] = TRUE;
-    $handler->display->display_options['fields']['aradu_count']['alter']['path'] = 'search/gene?gene_family=[phylotree_name]&abbreviation=aradu';
-    $handler->display->display_options['fields']['aradu_count']['alter']['absolute'] = TRUE;
-    /* Field: phylotree_count: Araip count */
-    $handler->display->display_options['fields']['araip_count']['id'] = 'araip_count';
-    $handler->display->display_options['fields']['araip_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['fields']['araip_count']['field'] = 'araip_count';
-    $handler->display->display_options['fields']['araip_count']['alter']['make_link'] = TRUE;
-    $handler->display->display_options['fields']['araip_count']['alter']['path'] = 'search/gene?gene_family=[phylotree_name]&abbreviation=araip';
-    $handler->display->display_options['fields']['araip_count']['alter']['absolute'] = TRUE;
-    /* Field: phylotree_count: Lupan count */
-    $handler->display->display_options['fields']['lupan_count']['id'] = 'lupan_count';
-    $handler->display->display_options['fields']['lupan_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['fields']['lupan_count']['field'] = 'lupan_count';
-    $handler->display->display_options['fields']['lupan_count']['alter']['make_link'] = TRUE;
-    $handler->display->display_options['fields']['lupan_count']['alter']['path'] = 'search/gene?gene_family=[phylotree_name]&abbreviation=lupan';
-    $handler->display->display_options['fields']['lupan_count']['alter']['absolute'] = TRUE;
+
+    /* Field: phylotree_count: Gene count by organism */
+    $handler->display->display_options['fields']['counts_by_org']['id'] = 'total_count';
+    $handler->display->display_options['fields']['counts_by_org']['table'] = 'phylotree_count';
+    $handler->display->display_options['fields']['counts_by_org']['field'] = 'counts_by_org';
+
     /* Filter criterion: phylotree_count: Family ID */
     $handler->display->display_options['filters']['phylotree_name']['id'] = 'phylotree_name';
     $handler->display->display_options['filters']['phylotree_name']['table'] = 'phylotree_count';
@@ -405,7 +226,7 @@ function tripal_phylotree_defaultvalue_user_phylotrees() {
             1 => 0,
             4 => 0,
         );
-        $handler->display->display_options['filters']['domains_con']['max_length'] = '40'; 
+        $handler->display->display_options['filters']['domains_con']['max_length'] = '40';
 
 
      }
@@ -416,7 +237,7 @@ function tripal_phylotree_defaultvalue_user_phylotrees() {
     $handler->display->display_options['filters']['total_count']['group'] = 1;
     $handler->display->display_options['filters']['total_count']['exposed'] = TRUE;
     $handler->display->display_options['filters']['total_count']['expose']['operator_id'] = 'total_count_op';
-    $handler->display->display_options['filters']['total_count']['expose']['label'] = 'Gene count';
+    $handler->display->display_options['filters']['total_count']['expose']['label'] = 'Total gene count';
     $handler->display->display_options['filters']['total_count']['expose']['use_operator'] = TRUE;
     $handler->display->display_options['filters']['total_count']['expose']['operator'] = 'total_count_op';
     $handler->display->display_options['filters']['total_count']['expose']['identifier'] = 'total_count';
@@ -425,221 +246,89 @@ function tripal_phylotree_defaultvalue_user_phylotrees() {
         1 => 0,
         4 => 0,
     );
-    /* Filter criterion: phylotree_count: Medtr count */
-    $handler->display->display_options['filters']['medtr_count']['id'] = 'medtr_count';
-    $handler->display->display_options['filters']['medtr_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['filters']['medtr_count']['field'] = 'medtr_count';
-    $handler->display->display_options['filters']['medtr_count']['group'] = 1;
-    $handler->display->display_options['filters']['medtr_count']['exposed'] = TRUE;
-    $handler->display->display_options['filters']['medtr_count']['expose']['operator_id'] = 'medtr_count_op';
-    $handler->display->display_options['filters']['medtr_count']['expose']['label'] = 'Medtr count';
-    $handler->display->display_options['filters']['medtr_count']['expose']['use_operator'] = TRUE;
-    $handler->display->display_options['filters']['medtr_count']['expose']['operator'] = 'medtr_count_op';
-    $handler->display->display_options['filters']['medtr_count']['expose']['identifier'] = 'medtr_count';
-    $handler->display->display_options['filters']['medtr_count']['expose']['remember_roles'] = array(
-        2 => '2',
-        1 => 0,
-        4 => 0,
-    );
-    /* Filter criterion: phylotree_count: Tripr count */
-    $handler->display->display_options['filters']['tripr_count']['id'] = 'tripr_count';
-    $handler->display->display_options['filters']['tripr_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['filters']['tripr_count']['field'] = 'tripr_count';
-    $handler->display->display_options['filters']['tripr_count']['group'] = 1;
-    $handler->display->display_options['filters']['tripr_count']['exposed'] = TRUE;
-    $handler->display->display_options['filters']['tripr_count']['expose']['operator_id'] = 'tripr_count_op';
-    $handler->display->display_options['filters']['tripr_count']['expose']['label'] = 'Tripr count';
-    $handler->display->display_options['filters']['tripr_count']['expose']['use_operator'] = TRUE;
-    $handler->display->display_options['filters']['tripr_count']['expose']['operator'] = 'tripr_count_op';
-    $handler->display->display_options['filters']['tripr_count']['expose']['identifier'] = 'tripr_count';
-    $handler->display->display_options['filters']['tripr_count']['expose']['remember_roles'] = array(
-        2 => '2',
-        1 => 0,
-        4 => 0,
-    );
-    /* Filter criterion: phylotree_count: Lotja count */
-    $handler->display->display_options['filters']['lotja_count']['id'] = 'lotja_count';
-    $handler->display->display_options['filters']['lotja_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['filters']['lotja_count']['field'] = 'lotja_count';
-    $handler->display->display_options['filters']['lotja_count']['group'] = 1;
-    $handler->display->display_options['filters']['lotja_count']['exposed'] = TRUE;
-    $handler->display->display_options['filters']['lotja_count']['expose']['operator_id'] = 'lotja_count_op';
-    $handler->display->display_options['filters']['lotja_count']['expose']['label'] = 'Lotja count';
-    $handler->display->display_options['filters']['lotja_count']['expose']['use_operator'] = TRUE;
-    $handler->display->display_options['filters']['lotja_count']['expose']['operator'] = 'lotja_count_op';
-    $handler->display->display_options['filters']['lotja_count']['expose']['identifier'] = 'lotja_count';
-    $handler->display->display_options['filters']['lotja_count']['expose']['remember_roles'] = array(
-        2 => '2',
-        1 => 0,
-        4 => 0,
-    );
-    /* Filter criterion: phylotree_count: Cicar count */
-    $handler->display->display_options['filters']['cicar_count']['id'] = 'cicar_count';
-    $handler->display->display_options['filters']['cicar_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['filters']['cicar_count']['field'] = 'cicar_count';
-    $handler->display->display_options['filters']['cicar_count']['group'] = 1;
-    $handler->display->display_options['filters']['cicar_count']['exposed'] = TRUE;
-    $handler->display->display_options['filters']['cicar_count']['expose']['operator_id'] = 'cicar_count_op';
-    $handler->display->display_options['filters']['cicar_count']['expose']['label'] = 'Cicar (CDCFrontier) count';
-    $handler->display->display_options['filters']['cicar_count']['expose']['use_operator'] = TRUE;
-    $handler->display->display_options['filters']['cicar_count']['expose']['operator'] = 'cicar_count_op';
-    $handler->display->display_options['filters']['cicar_count']['expose']['identifier'] = 'cicar_count';
-    $handler->display->display_options['filters']['cicar_count']['expose']['remember_roles'] = array(
-        2 => '2',
-        1 => 0,
-        4 => 0,
-    );
-    /* Filter criterion: phylotree_count: Glyma count */
-    $handler->display->display_options['filters']['glyma_count']['id'] = 'glyma_count';
-    $handler->display->display_options['filters']['glyma_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['filters']['glyma_count']['field'] = 'glyma_count';
-    $handler->display->display_options['filters']['glyma_count']['group'] = 1;
-    $handler->display->display_options['filters']['glyma_count']['exposed'] = TRUE;
-    $handler->display->display_options['filters']['glyma_count']['expose']['operator_id'] = 'glyma_count_op';
-    $handler->display->display_options['filters']['glyma_count']['expose']['label'] = 'Glyma count';
-    $handler->display->display_options['filters']['glyma_count']['expose']['use_operator'] = TRUE;
-    $handler->display->display_options['filters']['glyma_count']['expose']['operator'] = 'glyma_count_op';
-    $handler->display->display_options['filters']['glyma_count']['expose']['identifier'] = 'glyma_count';
-    $handler->display->display_options['filters']['glyma_count']['expose']['remember_roles'] = array(
-        2 => '2',
-        1 => 0,
-        4 => 0,
-    );
-    /* Filter criterion: phylotree_count: Phavu count */
-    $handler->display->display_options['filters']['phavu_count']['id'] = 'phavu_count';
-    $handler->display->display_options['filters']['phavu_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['filters']['phavu_count']['field'] = 'phavu_count';
-    $handler->display->display_options['filters']['phavu_count']['group'] = 1;
-    $handler->display->display_options['filters']['phavu_count']['exposed'] = TRUE;
-    $handler->display->display_options['filters']['phavu_count']['expose']['operator_id'] = 'phavu_count_op';
-    $handler->display->display_options['filters']['phavu_count']['expose']['label'] = 'Phavu count';
-    $handler->display->display_options['filters']['phavu_count']['expose']['use_operator'] = TRUE;
-    $handler->display->display_options['filters']['phavu_count']['expose']['operator'] = 'phavu_count_op';
-    $handler->display->display_options['filters']['phavu_count']['expose']['identifier'] = 'phavu_count';
-    $handler->display->display_options['filters']['phavu_count']['expose']['remember_roles'] = array(
-        2 => '2',
-        1 => 0,
-        4 => 0,
-    );
-    /* Filter criterion: phylotree_count: Cajca count */
-    $handler->display->display_options['filters']['cajca_count']['id'] = 'cajca_count';
-    $handler->display->display_options['filters']['cajca_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['filters']['cajca_count']['field'] = 'cajca_count';
-    $handler->display->display_options['filters']['cajca_count']['group'] = 1;
-    $handler->display->display_options['filters']['cajca_count']['exposed'] = TRUE;
-    $handler->display->display_options['filters']['cajca_count']['expose']['operator_id'] = 'cajca_count_op';
-    $handler->display->display_options['filters']['cajca_count']['expose']['label'] = 'Cajca count';
-    $handler->display->display_options['filters']['cajca_count']['expose']['use_operator'] = TRUE;
-    $handler->display->display_options['filters']['cajca_count']['expose']['operator'] = 'cajca_count_op';
-    $handler->display->display_options['filters']['cajca_count']['expose']['identifier'] = 'cajca_count';
-    $handler->display->display_options['filters']['cajca_count']['expose']['remember_roles'] = array(
-        2 => '2',
-        1 => 0,
-        4 => 0,
-    );
-    /* Filter criterion: phylotree_count: Vigun count */
-    $handler->display->display_options['filters']['vigun_count']['id'] = 'vigun_count';
-    $handler->display->display_options['filters']['vigun_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['filters']['vigun_count']['field'] = 'vigun_count';
-    $handler->display->display_options['filters']['vigun_count']['group'] = 1;
-    $handler->display->display_options['filters']['vigun_count']['exposed'] = TRUE;
-    $handler->display->display_options['filters']['vigun_count']['expose']['operator_id'] = 'vigun_count_op';
-    $handler->display->display_options['filters']['vigun_count']['expose']['label'] = 'Vigun count';
-    $handler->display->display_options['filters']['vigun_count']['expose']['use_operator'] = TRUE;
-    $handler->display->display_options['filters']['vigun_count']['expose']['operator'] = 'vigun_count_op';
-    $handler->display->display_options['filters']['vigun_count']['expose']['identifier'] = 'vigun_count';
-    $handler->display->display_options['filters']['vigun_count']['expose']['remember_roles'] = array(
-        2 => '2',
-        1 => 0,
-        4 => 0,
-    );
-    /* Filter criterion: phylotree_count: Vigra count */
-    $handler->display->display_options['filters']['vigra_count']['id'] = 'vigra_count';
-    $handler->display->display_options['filters']['vigra_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['filters']['vigra_count']['field'] = 'vigra_count';
-    $handler->display->display_options['filters']['vigra_count']['group'] = 1;
-    $handler->display->display_options['filters']['vigra_count']['exposed'] = TRUE;
-    $handler->display->display_options['filters']['vigra_count']['expose']['operator_id'] = 'vigra_count_op';
-    $handler->display->display_options['filters']['vigra_count']['expose']['label'] = 'Vigra count';
-    $handler->display->display_options['filters']['vigra_count']['expose']['use_operator'] = TRUE;
-    $handler->display->display_options['filters']['vigra_count']['expose']['operator'] = 'vigra_count_op';
-    $handler->display->display_options['filters']['vigra_count']['expose']['identifier'] = 'vigra_count';
-    $handler->display->display_options['filters']['vigra_count']['expose']['remember_roles'] = array(
-        2 => '2',
-        1 => 0,
-        4 => 0,
-    );
-    /* Filter criterion: phylotree_count: Vigan count */
-    $handler->display->display_options['filters']['vigan_count']['id'] = 'vigan_count';
-    $handler->display->display_options['filters']['vigan_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['filters']['vigan_count']['field'] = 'vigan_count';
-    $handler->display->display_options['filters']['vigan_count']['group'] = 1;
-    $handler->display->display_options['filters']['vigan_count']['exposed'] = TRUE;
-    $handler->display->display_options['filters']['vigan_count']['expose']['operator_id'] = 'vigan_count_op';
-    $handler->display->display_options['filters']['vigan_count']['expose']['label'] = 'Vigan count';
-    $handler->display->display_options['filters']['vigan_count']['expose']['use_operator'] = TRUE;
-    $handler->display->display_options['filters']['vigan_count']['expose']['operator'] = 'vigan_count_op';
-    $handler->display->display_options['filters']['vigan_count']['expose']['identifier'] = 'vigan_count';
-    $handler->display->display_options['filters']['vigan_count']['expose']['remember_roles'] = array(
-        2 => '2',
-        1 => 0,
-        4 => 0,
-    );
-    /* Filter criterion: phylotree_count: Aradu count */
-    $handler->display->display_options['filters']['aradu_count']['id'] = 'aradu_count';
-    $handler->display->display_options['filters']['aradu_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['filters']['aradu_count']['field'] = 'aradu_count';
-    $handler->display->display_options['filters']['aradu_count']['group'] = 1;
-    $handler->display->display_options['filters']['aradu_count']['exposed'] = TRUE;
-    $handler->display->display_options['filters']['aradu_count']['expose']['operator_id'] = 'aradu_count_op';
-    $handler->display->display_options['filters']['aradu_count']['expose']['label'] = 'Aradu count';
-    $handler->display->display_options['filters']['aradu_count']['expose']['use_operator'] = TRUE;
-    $handler->display->display_options['filters']['aradu_count']['expose']['operator'] = 'aradu_count_op';
-    $handler->display->display_options['filters']['aradu_count']['expose']['identifier'] = 'aradu_count';
-    $handler->display->display_options['filters']['aradu_count']['expose']['remember_roles'] = array(
-        2 => '2',
-        1 => 0,
-        4 => 0,
-    );
-    /* Filter criterion: phylotree_count: Araip count */
-    $handler->display->display_options['filters']['araip_count']['id'] = 'araip_count';
-    $handler->display->display_options['filters']['araip_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['filters']['araip_count']['field'] = 'araip_count';
-    $handler->display->display_options['filters']['araip_count']['group'] = 1;
-    $handler->display->display_options['filters']['araip_count']['exposed'] = TRUE;
-    $handler->display->display_options['filters']['araip_count']['expose']['operator_id'] = 'araip_count_op';
-    $handler->display->display_options['filters']['araip_count']['expose']['label'] = 'Araip count';
-    $handler->display->display_options['filters']['araip_count']['expose']['use_operator'] = TRUE;
-    $handler->display->display_options['filters']['araip_count']['expose']['operator'] = 'araip_count_op';
-    $handler->display->display_options['filters']['araip_count']['expose']['identifier'] = 'araip_count';
-    $handler->display->display_options['filters']['araip_count']['expose']['remember_roles'] = array(
-        2 => '2',
-        1 => 0,
-        4 => 0,
-    );
-    /* Filter criterion: phylotree_count: Lupan count */
-    $handler->display->display_options['filters']['lupan_count']['id'] = 'lupan_count';
-    $handler->display->display_options['filters']['lupan_count']['table'] = 'phylotree_count';
-    $handler->display->display_options['filters']['lupan_count']['field'] = 'lupan_count';
-    $handler->display->display_options['filters']['lupan_count']['group'] = 1;
-    $handler->display->display_options['filters']['lupan_count']['exposed'] = TRUE;
-    $handler->display->display_options['filters']['lupan_count']['expose']['operator_id'] = 'lupan_count_op';
-    $handler->display->display_options['filters']['lupan_count']['expose']['label'] = 'Lupan count';
-    $handler->display->display_options['filters']['lupan_count']['expose']['use_operator'] = TRUE;
-    $handler->display->display_options['filters']['lupan_count']['expose']['operator'] = 'lupan_count_op';
-    $handler->display->display_options['filters']['lupan_count']['expose']['identifier'] = 'lupan_count';
-    $handler->display->display_options['filters']['lupan_count']['expose']['remember_roles'] = array(
-        2 => '2',
-        1 => 0,
-        4 => 0,
-    );
 
     /* Display: Phylotree */
     $handler = $view->new_display('page', 'Phylotree', 'page');
     $handler->display->display_options['path'] = 'search/phylotree';
-    
-    // End of exported code here 
+
+    // End of exported code here
 
     return $view;
 
+}
+
+
+function tripal_phylotree_views_pre_view(&$view, &$display_id, &$args) {
+  if ($view->name == 'phylotree') {
+
+    $organisms = tripal_phylotree_get_orgs();
+
+    foreach($organisms as $org_id => $org) {
+      $view->add_item($view->current_display, 'field', 'phylotree_count', $org_id.'_count', array(
+        'label' => $organisms[$org_id]['genus'].' '.$organisms[$org_id]['species'].' count',
+        'table' => 'phylotree_count',
+        'field' => $org_id.'_count',
+        'counts_by_org' => '[counts_by_org]',
+        'alter' => array(
+          'make_link' => TRUE,
+          'path' => 'chado_phylotree/[phylotree_name]'
+        )
+      ), $org_id.'_count');
+    }
+  }
+}
+
+function tripal_phylotree_views_pre_render(&$view) {
+  // Hide field containing json data
+  if ($view->name == 'phylotree') {
+    $view->field['counts_by_org']->options['exclude'] = TRUE;
+  }
+}
+
+function tripal_phylotree_views_data_alter(&$data) {
+
+  $organisms = tripal_phylotree_get_orgs();
+
+  foreach($organisms as $org_id => $org) {
+    $data['phylotree_count'][$org_id.'_count'] = array(
+        'title' => $organisms[$org_id]['genus'].' '.$organisms[$org_id]['species'].' count',
+        'real field' => 'counts_by_org',
+        'field' => array(
+          'handler' => 'tripal_phylotree_views_handler_field_org_count',
+          // As these fields are auto generated, there's no way to sort it at sql level
+          // https://drupal.stackexchange.com/questions/150169/sort-handler-for-pseudo-field-in-views
+          'click sortable' => FALSE,
+        ),
+    );
+  }
+}
+
+function tripal_phylotree_views_handlers() {
+  return array(
+    'info' => array(
+      'path' => drupal_get_path('module', 'tripal_phylotree') . '/views/handlers',
+    ),
+    'handlers' => array(
+      'tripal_phylotree_views_handler_field_org_count' => array(
+        'parent' => 'views_handler_field',
+      ),
+    )
+  );
+}
+
+function tripal_phylotree_get_orgs() {
+    // List organisms with at least 1 feature in a tree
+    $sql = 'SELECT o.abbreviation, o.genus, o.species, o.organism_id '.
+      'FROM chado.phylonode n '.
+      'LEFT OUTER JOIN chado.feature f ON n.feature_id = f.feature_id '.
+      'LEFT OUTER JOIN chado.organism o ON f.organism_id = o.organism_id '.
+      'WHERE n.feature_id IS NOT NULL '.
+      'GROUP BY o.organism_id';
+    $results = chado_query($sql, array());
+    $organisms = array();
+    foreach($results as $r) {
+      $organisms[$r->organism_id] = array('genus' => $r->genus, 'species' => $r->species, 'abbr' => $r->abbreviation);
+    }
+
+    return $organisms;
 }

--- a/theme/js/aurelia/aurelia_project/aurelia.json
+++ b/theme/js/aurelia/aurelia_project/aurelia.json
@@ -122,7 +122,7 @@
           },
 					{
 						"name": "crossfilter2",
-						"path": "../node_modules/crossfilter2/crossfilter"	          
+						"path": "../node_modules/crossfilter2/crossfilter"
 					},
 					{
 						"name" : "tnt.tree",

--- a/theme/js/aurelia/src/api.js
+++ b/theme/js/aurelia/src/api.js
@@ -1,6 +1,6 @@
 /* a singleton/service for loading source data files and managing crossfilter
  * objects.
- * 
+ *
  * note: all http error handling is in the app.js http interceptor.
  */
 
@@ -24,13 +24,13 @@ export class Api {
 	// declare some observable properties for use by other vis. elements:
 	@observable cf; // crossfilter object
 	@observable cfUpdated; // a crossfilter updated message
-	
+
   treeData = null;
   msaSeqs = null;
 	loading = true;
   flatData = []; // same as tree leaves
   index = {};
-	
+
   constructor(http) {
     this.http = http;
   }
@@ -47,18 +47,18 @@ export class Api {
     });
 		return p3;
   }
-	
+
   // by convention, the consensus seq is the first in the msa seqs array.
   getConsensusSeq() {
     return (this.msaSeqs[0].name.endsWith("-consensus") ? this.msaSeqs[0] : undefined);
   }
-	
+
   setupCrossFilter() {
     // create crossfilter from flat data, not from tree data.
     let msg = null;
 		this.cf = crossfilter(this.flatData);
   }
-	
+
   getTreeData() {
 		if(treeData) {
 			// have global var from the php template
@@ -77,7 +77,7 @@ export class Api {
 			return promise;
 		}
   }
-	
+
   getMsaData() {
     let promise = this.http.fetch(this.MSA_URL)
         .then(res => res.text())
@@ -88,7 +88,7 @@ export class Api {
         });
     return promise;
   }
-	
+
   // postProcess() : add the corresponding MSA sequence to each record in the
   // flatData set.
   postProcess() {
@@ -102,12 +102,12 @@ export class Api {
       }
     });
   }
-	
+
   // parseTree() : build an index of names, add properties as needed, and
   // create a flattened version of the tree.
   parseTree(node) {
     let that = this;
-		
+
     if (! node.name) {
       node.name = '';
     }

--- a/theme/js/aurelia/src/app.html
+++ b/theme/js/aurelia/src/app.html
@@ -25,23 +25,23 @@
 			MSA visualization
 		</a>
 	</div>
-	
+
 	<help show-dialog.two-way="tools.help"></help>
-	
+
 	<tree show-dialog.two-way="tools.tree"
 		    family-name.one-time="familyName"
 		    ref="treeEl""
 		    msa-el.bind="msaEl">
 	</tree>
-	
+
 	<taxon show-dialog.two-way="tools.taxon"
 		     family-name.one-time="familyName">
 	</taxon>
-	
+
 	<msa show-dialog.two-way="tools.msa"
 		   family-name.one-time="familyName"
 		   tree-el.bind="treeEl"
 		   ref="msaEl">
 	</msa>
-	
+
 </template>

--- a/theme/js/aurelia/src/resources/elements/tree.html
+++ b/theme/js/aurelia/src/resources/elements/tree.html
@@ -43,7 +43,7 @@
         </div>
       </fieldset>
   </form>
-	
+
 	<div if.bind="(! api.loading) && hiliteFeaturesCount"
 		   style="margin-top: 10px">
 		Jump to hilited feature:
@@ -72,13 +72,13 @@
      ${newickExport}
     </code>
 	</div>
-	
+
 	<div id="phylogram-axis" ref="phylogramAxisElement">
   </div>
-	
+
   <div id="phylogram" style="margin-bottom: 100px" ref="phylogramElement">
   </div>
-		
+
 	<div id="node-dialog" ref="nodeDialogEl" style="display: none">
 		<div if.bind="node.is_leaf() && ! node.is_collapsed()">
 			<!-- leaf node linkouts -->
@@ -89,7 +89,7 @@
 				</a>
 			</div>
 		</div>
-		
+
 		<div if.bind="! node.is_leaf() || node.is_collapsed()">
 			<div>
 				<a class="link" href="#" click.delegate="onNodeToggle()" tabindex="-1">
@@ -167,5 +167,5 @@
 		</div>
 		<loader-anim if.bind="loading"></loader-anim>
 	</div>
-			
+
 </template>

--- a/theme/js/aurelia/src/resources/elements/tree.js
+++ b/theme/js/aurelia/src/resources/elements/tree.js
@@ -14,11 +14,11 @@ export class Tree {
 	LABEL_BASELINE_SHIFT = '30%';
 	AXIS_TICKS = 12;
 	AXIS_SAMPLE_PX = 30; // pixels
-	
+
 	@bindable familyName; // family-name attribute of <tree> element
 	@bindable msaEl;      // reference to <msa> element
 	@bindable showDialog; // two-way databinding for toggling dialog in app.js
-	
+
 	msa = null;           // msa view-model
 	selectedLayout = 'vertical';
 	hiliteFeatures = {};
@@ -28,7 +28,7 @@ export class Tree {
 	rootNodeDirty = false; // flag for has user refocused the tree on some node.
 	showSingletonNodes = true; // when refocused on a subtree.
 	singletonNodeNum = 0;
-	
+
   _rootNode = null; // initially _rootNode is same as api.treeData, but my be
 										// updated by onNodeFocusTree.
   _tree = null;
@@ -84,7 +84,7 @@ export class Tree {
 			.filter((d) => this.isLegume(d))
 			.classed('legume', true);
 	}
-	
+
 	// add a css class to all singleton nodes, so they can be themed or hidden.
 	decorateSingletonNodes() {
 		// add css classes to singleton nodes, and count the number of singleton
@@ -112,7 +112,7 @@ export class Tree {
 		d3.selectAll('#phylogram .singleton-node')
 			.classed('singleton-node-visible', show);
 	}
-	
+
   subscribe() {
 		this.be.propertyObserver(this.api, 'cf')
 		 	.subscribe(o => this.onCfCreated(o));
@@ -134,11 +134,11 @@ export class Tree {
 		this.hiliteFeatures = _.zipObject(names, vals);
 		this.hiliteFeaturesCount = names.length;
 		this._tree.update_nodes(); // use tree api to refersh tree nodes & labels.
-		this.updateLeafNodeHilite(false); 
+		this.updateLeafNodeHilite(false);
 	}
 
 	// tnt.tree api does not support selections or hiliting that I can
-	// see, so use d3 to decorate the currently selected features with a 
+	// see, so use d3 to decorate the currently selected features with a
 	// hilited css style.
 	updateLeafNodeHilite(scroll) {
 		let that = this;
@@ -174,7 +174,7 @@ export class Tree {
 			$('html,body').attr('scrollTop',  top - 100);
 		}
 	}
-	
+
 	/*
 	 * onScrollToHilite() : use jquery to scroll to the tree element
 	 * with selector like #tnt_tree_node_phylogram_{id} (id is the
@@ -189,20 +189,20 @@ export class Tree {
 		let offset = $(selector).offset();
 		$('html,body').attr('scrollTop',  offset.top - 100);
 	}
-	
+
 	onCfCreated(cf) {
     this._cf = cf;
 		// create a dimension by name (keep our own instance of this dimension)
     this._dim = cf.dimension(d => d.name);
     this.init();
 	}
-	
+
 	onCfUpdated(msg) {
 		if(msg.sender != this) {
 			this.update();
 		}
 	}
-	
+
   // init() : create the tnt.tree chart
   init() {
 		let that = this;
@@ -248,7 +248,7 @@ export class Tree {
 		this._tree.on('click', node => this.onTreeNodeClick(node) );
 		this._tree.on('mouseover', node => this.onNodeMouseover(node));
 		this._tree.on('mouseout', node => this.onNodeMouseout(node));
-		
+
 		// display the tree with msa tnt.tree component
     this._tree(this.phylogramElement);
 
@@ -262,7 +262,7 @@ export class Tree {
 			.attr('transform', 'translate(20,20)')
 			.attr('class', 'x axis')
 			.call(this.getXAxis(distance));
-		
+
 		// perform final ui tweaks after rendering the tree
 		this.decorateLeafNodes();
 		if(_.keys(this.hiliteFeatures).length) {
@@ -281,11 +281,11 @@ export class Tree {
 				.orient('bottom');
 		return axis;
 	}
-	
+
 	updateXAxis() {
 		d3.selectAll('#phylogram-axis g.x.axis').call(this.getXAxis());
 	}
-	
+
 	// lookup the node with jquery and return a jquery element
 	node2jquery(node) {
 		let nodeSelector = this.node2jquerySelector(node);
@@ -294,9 +294,9 @@ export class Tree {
 	}
 
 	node2jquerySelector(node) {
-		return '#tnt_tree_node_phylogram_'+ node.id();		
+		return '#tnt_tree_node_phylogram_'+ node.id();
 	}
-	
+
 	onNodeMouseover(node) {
 		let el = this.node2jquery(node);
     el.attr('cursor', 'pointer');
@@ -304,9 +304,9 @@ export class Tree {
 
 	onNodeMouseout(node) {
 		let el = this.node2jquery(node);
-    el.attr('cursor', 'default');		
+    el.attr('cursor', 'default');
 	}
-	
+
 	// get the fill color of each node
 	getNodeColor(node) {
 		if(node.is_leaf() && ! node.is_collapsed()) {
@@ -321,7 +321,7 @@ export class Tree {
 		let legumeGenera = this.symbology.legumes;
 		return d.genus.toLowerCase() in legumeGenera;
 	}
-	
+
   onTreeNodeClick(node) {
 		this.loading = true;
 		let that = this;
@@ -409,7 +409,7 @@ export class Tree {
 			// the visibleLeaves count includes 1 collapsed node
 			this.hiddenLeavesNum += 1;
 		}
-		
+
     let visibleNodes = {};
     _.forEach(visibleLeaves, (node) => {
       let n = node.data().name;
@@ -486,7 +486,7 @@ export class Tree {
 		$('html,body').attr('scrollTop', 0);
 		new Clipboard('#newick-export button');
 	}
-	
+
 	/* return array of feature names. this can be used elsewhere like
 	 * the msa component */
 	getSortOrder() {

--- a/theme/templates/tripal_phylotree_analysis.tpl.php
+++ b/theme/templates/tripal_phylotree_analysis.tpl.php
@@ -25,7 +25,7 @@ $rows = array();
 
 if($analysis) {
   $analysis = chado_expand_var($analysis, 'field', 'analysis.description');
-  $rows[] = array($analysis->name, $analysis->description, 
+  $rows[] = array($analysis->name, $analysis->description,
       sprintf('%s %s %s %s %s %s %s',
           $analysis->program,
           $analysis->programversion,
@@ -39,7 +39,7 @@ else {
   // degrade gracefully if no analysis is present
   $rows[] = array('n/a','','');
 }
-   
+
 $table = array(
   'header' => $header,
   'rows' => $rows,

--- a/theme/templates/tripal_phylotree_base.tpl.php
+++ b/theme/templates/tripal_phylotree_base.tpl.php
@@ -11,6 +11,7 @@ if(empty($my_path)) {
   // note: there is no leading '/' because that is the format used by
   // path_to_theme(), even though this is effectively an absolute url.
 }
+
 $phylotree = $variables['node']->phylotree;
 
 drupal_add_css(
@@ -40,8 +41,8 @@ printf("var THEME_PATH = '/%s';\n", $my_path);
 
 // write the tree data into the template as js var (saving one ajax
 // get for json)
-// if the tree has been provided as post data, write that instead. 
-// in that case there should also be an url provided to get the MSA. 
+// if the tree has been provided as post data, write that instead.
+// in that case there should also be an url provided to get the MSA.
 if (!isset($_POST["json"]))
 {
 	// write js var having URL of json and gff data sources
@@ -88,7 +89,7 @@ if( ! empty($phylotree->comment) ) {
 </div>
 
 <div id="ahrd-dialog" style="display:none; font-size: 0.8rem">
-    
+
 <a href="https://github.com/groupschoof/AHRD"
    class="ext" tabindex="-1">AHRD's<span class="ext"></span></a>
 quality-code consists of a four character string, where each
@@ -120,12 +121,12 @@ meaning is explained in the following table:
 </tbody></table>
 
 </div>
-    
+
 <div id="ajax-spinner">
     <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
     <span class="sr-only">Loading...</span>
 </div>
-    
+
 <div id="au-content" aurelia-app="main">
 </div>
 
@@ -143,7 +144,7 @@ meaning is explained in the following table:
 $js_config = array('type' => 'external', 'group' => JS_LIBRARY);
 drupal_add_js(
     '//cdn.bio.sh/msa/1.0/msa.min.gz.js',
-    $js_config    
+    $js_config
 );
 drupal_add_js(
     '//cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js',
@@ -159,11 +160,11 @@ drupal_add_js(
 );
 drupal_add_js(
     '//cdnjs.cloudflare.com/ajax/libs/chroma-js/1.2.1/chroma.min.js',
-    $js_config    
+    $js_config
 );
 drupal_add_js(
     '//cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.5.15/clipboard.min.js',
-    $js_config    
+    $js_config
 );
 
 drupal_add_library('system', 'ui.dialog');

--- a/tripal_phylotree.install
+++ b/tripal_phylotree.install
@@ -1,14 +1,14 @@
 <?php
 /**
- * @file
- * Installation of the phylotree module
- */
+* @file
+* Installation of the phylotree module
+*/
 
 /**
- * Implementation of hook_requirements().
- *
- * @ingroup tripal_phylotree
- */
+* Implementation of hook_requirements().
+*
+* @ingroup tripal_phylotree
+*/
 function tripal_phylotree_requirements($phase) {
   $requirements = array();
   if ($phase == 'install') {
@@ -28,93 +28,90 @@ function tripal_phylotree_requirements($phase) {
 /* hook_enable()*/
 
 function tripal_phylotree_enable(){
-$permissions = array('access chado_phylotree content');
-tripal_phylotree_grant_permissions(DRUPAL_AUTHENTICATED_RID, $permissions);
-$permissions_anonym = array('access chado_phylotree content');
-tripal_phylotree_grant_permissions(DRUPAL_ANONYMOUS_RID, $permissions_anonym);
-$permissions_admin = array('administer tripal phylotree');
-tripal_phylotree_grant_permissions (DRUPAL_AUTHENTICATED_RID, $permissions_admin);
-
-
+  $permissions = array('access chado_phylotree content');
+  tripal_phylotree_grant_permissions(DRUPAL_AUTHENTICATED_RID, $permissions);
+  $permissions_anonym = array('access chado_phylotree content');
+  tripal_phylotree_grant_permissions(DRUPAL_ANONYMOUS_RID, $permissions_anonym);
+  $permissions_admin = array('administer tripal phylotree');
+  tripal_phylotree_grant_permissions (DRUPAL_AUTHENTICATED_RID, $permissions_admin);
 }
 
 
 /**
- * Implements hook_install()
- * Allows installation of the tripal_gene module
- */
-
+* Implements hook_install()
+* Allows installation of the tripal_gene module
+*/
 function tripal_phylotree_install() {
-  $sql_count ="select count(f.feature_id) as count
-        from feature f left join cvterm cvt
-        on f.type_id=cvt.cvterm_id
-      where cvt.name = :name";
+
+  // Add the vocabularies used by the phylotree module.
+  tripal_phylotree_add_cvterms();
+
+  $sql_count = "select count(f.feature_id) as count
+  from feature f left join cvterm cvt
+  on f.type_id=cvt.cvterm_id
+  where cvt.name = :name";
 
   $args = array(':name' => 'polypeptide_domain');
   $result = chado_query($sql_count, $args)->fetchObject();
-  if ($result->count > 0) {
-      
-    // add the materializedviews
-    tripal_phylotree_add_mview();  
 
-    // we want to integrate the materialized views so that they
-    // are available for Drupal Views, upon which our search forms are built
-    tripal_phylotree_integrate_view();
+  $use_domain = ($result->count > 0);
 
+  // add the materialized views
+  if ($use_domain) {
+    tripal_phylotree_add_tree2domain_mview();
+  }
+
+  tripal_phylotree_add_phylotree_count_mview($use_domain);
+
+  // we want to integrate the materialized views so that they
+  // are available for Drupal Views, upon which our search forms are built
+  tripal_phylotree_integrate_view($use_domain);
+
+  if ($use_domain) {
     $mview_id =  tripal_get_mview_id('tree2domain');
     print "\nPopulating tree2domain mview.....\n";
     tripal_populate_mview($mview_id);
-  } else {
-      // add the materialized view with no domain data
-      tripal_phylotree_add_domainless_mview();
+  }
 
-      // we want to integrate the materialized views so that they
-      // are available for Drupal Views, upon which our search forms are built
-      tripal_phylotree_integrate_view();
-  }      
-
-    
-    $mview_id =  tripal_get_mview_id('phylotree_count');   
-    print "\nPopulating phylotree_count mview.....\n";  
-    tripal_populate_mview($mview_id);
-
+  $mview_id = tripal_get_mview_id('phylotree_count');
+  print "\nPopulating phylotree_count mview.....\n";
+  tripal_populate_mview($mview_id);
 }
 
 
 /**
- * Implementation of hook_grant_permissions(). peu added
- */
-
+* Implementation of hook_grant_permissions(). peu added
+*/
 function tripal_phylotree_grant_permissions($rid, array $permissions = array()) {
 
-   // this line doesn't work on install / enable hooks
-     $modules = user_permission_get_modules();
-    // Grant new permissions for the role.
-    foreach ($permissions as $name) {
-        db_merge('role_permission')
-        ->key(array(
-            'rid' => $rid,
-            'permission' => $name,
-        ))
-        ->fields(array(
+  // this line doesn't work on install / enable hooks
+  $modules = user_permission_get_modules();
+  // Grant new permissions for the role.
+  foreach ($permissions as $name) {
+    db_merge('role_permission')
+    ->key(array(
+      'rid' => $rid,
+      'permission' => $name,
+    ))
+    ->fields(array(
       //hard-coded module name here as $modules was not working -peu
-           'module' => 'tripal_phylotree',
-       ))
-        ->execute();
-    }
+      'module' => 'tripal_phylotree',
+    ))
+    ->execute();
+  }
 
 
-    // Clear the user access cache.
-    drupal_static_reset('user_access');
-    drupal_static_reset('user_role_permissions');
+  // Clear the user access cache.
+  drupal_static_reset('user_access');
+  drupal_static_reset('user_role_permissions');
 }
 
 
 /**
- * Implementation of hook_schema().
- * Standard tripal linker table between a node and a phylotree record.
- * @ingroup tripal_phylotree
- */
+* Implementation of hook_schema().
+* Standard tripal linker table between a node and a phylotree record.
+* @ingroup tripal_phylotree
+*/
 function tripal_phylotree_schema() {
   $schema['chado_phylotree'] = array(
     'fields' => array(
@@ -149,303 +146,64 @@ function tripal_phylotree_schema() {
 }
 
 /**
- * Implementation of hook_uninstall().
- */
+* Implementation of hook_uninstall().
+*/
 function tripal_phylotree_uninstall() {
 
-    // Drop the MView table if it exists
-    $mview_id =  tripal_get_mview_id('phylotree_count');
-    if ($mview_id) {
-        tripal_delete_mview($mview_id);
-    }
+  // Drop the MView table if it exists
+  $mview_id =  tripal_get_mview_id('phylotree_count');
+  if ($mview_id) {
+    tripal_delete_mview($mview_id);
+  }
+  //Remove views integration
+  // Note: tripal_remove_views_intergration accepts table_name and priority in a key value form.
+
+  $delete_view=array(
+    'table_name' => 'phylotree_count',
+    'priority' => '-1',
+  );
+  tripal_remove_views_integration($delete_view);
+
+  // Drop the MView table if it exists
+  $mview_id =  tripal_get_mview_id('tree2domain');
+  if ($mview_id) {
+    tripal_delete_mview($mview_id);
+
     //Remove views integration
-    // Note: tripal_remove_views_intergration accepts table_name and priority in a key value form. 
+    // Note: tripal_remove_views_intergration accepts table_name and priority in a key value form.
 
     $delete_view=array(
-        'table_name' => 'phylotree_count',
-        'priority' => '-1',
+      'table_name' => 'tree2domain',
+      'priority' => '-1',
     );
-    tripal_remove_views_integration($delete_view); 
-
-    // Drop the MView table if it exists
-    $mview_id =  tripal_get_mview_id('tree2domain');
-    if ($mview_id) {
-        tripal_delete_mview($mview_id);
-
-        //Remove views integration
-        // Note: tripal_remove_views_intergration accepts table_name and priority in a key value form.
-
-        $delete_view=array(
-            'table_name' => 'tree2domain',
-            'priority' => '-1',
-        );
-        tripal_remove_views_integration($delete_view);
-    }
+    tripal_remove_views_integration($delete_view);
+  }
 }
 
 
-function tripal_phylotree_add_domainless_mview(){
-    //Materialized view addition
+function tripal_phylotree_add_phylotree_count_mview($with_domain = FALSE) {
+  //Materialized view addition
 
-        $sql_query="WITH count_genes as (select count(*) count, t.phylotree_id from phylotree t, phylonode n where n.phylotree_id=t.phylotree_id and n.label is not null group by t.phylotree_id),
-count_medtr_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'medtr.%' group by t.phylotree_id),
-count_tripr_genes as (select count(fp.value) count, t.phylotree_id from phylotree t left outer join featureprop fp on fp.value=t.name inner join feature f on fp.feature_id=f.feature_id and f.name like 'tripr.%' group by t.phylotree_id),
-count_lotja_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'lotja.%' group by t.phylotree_id),
-count_cicar_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'cicar.%' group by t.phylotree_id),
-count_cajca_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'cajca.%' group by t.phylotree_id),
-count_vigun_genes as (select count(fp.value) count, t.phylotree_id from phylotree t left outer join featureprop fp on fp.value=t.name inner join feature f on fp.feature_id=f.feature_id and f.name like 'vigun.%' group by t.phylotree_id),
-count_vigra_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'vigra.%' group by t.phylotree_id),
-count_vigan_genes as (select count(fp.value) count, t.phylotree_id from phylotree t left outer join featureprop fp on fp.value=t.name inner join feature f on fp.feature_id=f.feature_id and f.name like 'vigan.%' group by t.phylotree_id),
-count_phavu_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'phavu.%' group by t.phylotree_id),
-count_aradu_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'aradu.%' group by t.phylotree_id),
-count_araip_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'araip.%' group by t.phylotree_id),
-count_lupan_genes as (select count(fp.value) count, t.phylotree_id from phylotree t left outer join featureprop fp on fp.value=t.name inner join feature f on fp.feature_id=f.feature_id and f.name like 'lupan.%' group by t.phylotree_id),
-count_glyma_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'glyma.%' group by t.phylotree_id)
-SELECT
-phylotree.phylotree_id AS phylotree_phylotree_id,
-phylotree.name AS phylotree_name,
-phylotree.comment AS phylotree_comment,
-count_genes.count as total_count,
-count_medtr_genes.count as medtr_count,
-coalesce(count_tripr_genes.count,0) as tripr_count,
-count_lotja_genes.count as lotja_count,
-count_cicar_genes.count as cicar_count,
-count_glyma_genes.count as glyma_count,
-count_phavu_genes.count as phavu_count,
-count_cajca_genes.count as cajca_count,
-count_vigun_genes.count as vigun_count,
-count_vigra_genes.count as vigra_count,
-coalesce(count_vigan_genes.count,0) as vigan_count,
-count_aradu_genes.count as aradu_count,
-count_araip_genes.count as araip_count,
-coalesce(count_lupan_genes.count,0) as lupan_count
-FROM chado.phylotree phylotree
-LEFT JOIN chado_phylotree chado_phylotree ON phylotree.phylotree_id = chado_phylotree.phylotree_id
-LEFT JOIN count_genes count_genes ON phylotree.phylotree_id = count_genes.phylotree_id
-LEFT JOIN count_medtr_genes ON phylotree.phylotree_id = count_medtr_genes.phylotree_id
-LEFT JOIN count_tripr_genes ON phylotree.phylotree_id = count_tripr_genes.phylotree_id
-LEFT JOIN count_lotja_genes ON phylotree.phylotree_id = count_lotja_genes.phylotree_id
-LEFT JOIN count_cicar_genes ON phylotree.phylotree_id = count_cicar_genes.phylotree_id
-LEFT JOIN count_glyma_genes ON phylotree.phylotree_id = count_glyma_genes.phylotree_id
-LEFT JOIN count_phavu_genes ON phylotree.phylotree_id = count_phavu_genes.phylotree_id
-LEFT JOIN count_cajca_genes ON phylotree.phylotree_id = count_cajca_genes.phylotree_id
-LEFT JOIN count_vigun_genes ON phylotree.phylotree_id = count_vigun_genes.phylotree_id
-LEFT JOIN count_vigra_genes ON phylotree.phylotree_id = count_vigra_genes.phylotree_id
-LEFT JOIN count_vigan_genes ON phylotree.phylotree_id = count_vigan_genes.phylotree_id
-LEFT JOIN count_aradu_genes ON phylotree.phylotree_id = count_aradu_genes.phylotree_id
-LEFT JOIN count_araip_genes ON phylotree.phylotree_id = count_araip_genes.phylotree_id
-LEFT JOIN count_lupan_genes ON phylotree.phylotree_id = count_lupan_genes.phylotree_id
-JOIN analysis a ON phylotree.analysis_id=a.analysis_id JOIN analysisprop ap ON ap.analysis_id=a.analysis_id JOIN cvterm ct ON ap.type_id=ct.cvterm_id
-WHERE ct.name='is_current'
-";
+  $sql_query = "WITH
+                count_genes AS (SELECT count(*) count, t.phylotree_id FROM phylotree t, phylonode n WHERE n.phylotree_id=t.phylotree_id AND n.label IS NOT null GROUP BY t.phylotree_id),
+                counts AS (SELECT t.phylotree_id as tree_id, organism_id, count(n.phylonode_id) AS count from phylotree t LEFT OUTER JOIN phylonode n ON n.phylotree_id=t.phylotree_id JOIN feature f ON f.feature_id = n.feature_id GROUP BY t.phylotree_id, organism_id),
+                json_counts AS (SELECT tree_id, json_agg(json_build_object(organism_id, count)) AS counts_by_org FROM counts GROUP BY tree_id)
+                SELECT
+                phylotree.phylotree_id AS phylotree_phylotree_id,
+                phylotree.name AS phylotree_name,
+                phylotree.comment AS phylotree_comment,
+                count_genes.count AS total_count,
+                json_counts.counts_by_org AS counts_by_org
+                FROM chado.phylotree phylotree
+                LEFT JOIN chado_phylotree chado_phylotree ON phylotree.phylotree_id = chado_phylotree.phylotree_id
+                LEFT JOIN count_genes count_genes ON phylotree.phylotree_id = count_genes.phylotree_id
+                LEFT JOIN json_counts json_counts ON phylotree.phylotree_id = json_counts.tree_id";
 
-        //Table Phylotree User Search  description
+  //Table Phylotree User Search  description
 
-        $schema = array (
-            'table' => 'phylotree_count',
-            'fields' => array(
-                'phylotree_phylotree_id' => array(
-                    'type' => 'int',
-                    'not null' => FALSE,
-                ),
-                'phylotree_name' => array(
-                    'type' => 'text',
-                    'not null' => FALSE,
-                ),
-                'phylotree_comment' => array(
-                    'type' => 'text',
-                    'not null' => FALSE,
-                ),
-                'total_count' => array(
-                    'type' => 'int',
-                    'not null' => TRUE,
-                ),
-                'medtr_count' => array(
-                    'type' => 'int',
-                    'not null' => TRUE,
-                ),
-                'tripr_count' => array(
-                    'type' => 'int',
-                    'not null' => TRUE,
-                ),
-                'lotja_count' => array(
-                    'type' => 'int',
-                    'not null' => TRUE,
-                ),
-                'cicar_count' => array(
-                    'type' => 'int',
-                    'not null' => TRUE,
-                ),
-                'glyma_count' => array(
-                    'type' => 'int',
-                    'not null' => TRUE,
-                ),
-                'phavu_count' => array(
-                    'type' => 'int',
-                    'not null' => TRUE,
-                ),
-                'cajca_count' => array(
-                    'type' => 'int',
-                    'not null' => TRUE,
-                ),
-                'vigun_count' => array(
-                    'type' => 'int',
-                    'not null' => TRUE,
-                ),
-                'vigra_count' => array(
-                    'type' => 'int',
-                    'not null' => TRUE,
-                ),
-                'vigan_count' => array(
-                    'type' => 'int',
-                    'not null' => TRUE,
-                ),
-                'aradu_count' => array(
-                    'type' => 'int',
-                    'not null' => TRUE,
-                ),
-                'araip_count' => array(
-                    'type' => 'int',
-                    'not null' => TRUE,
-                ),
-                'lupan_count' => array(
-                    'type' => 'int',
-                    'not null' => TRUE,
-                ),
-            ),
-            'primary key' => array('phylotree_phylotree_id'),
-        );
-
-        // add a comment to make sure this view makes sense to the site administator
-        $comment = t('This view is used to provide a table for Phylotree User Search with total- and per species- counts.');
-        tripal_add_mview(
-            'phylotree_count', // name of materialized view
-            'tripal_phylotree', // name of module submitting view
-            $schema,      // schema api array representation
-            $sql_query,         // sql query that loads the mview
-            $comment );
-
-}
-
-
-function tripal_phylotree_add_mview(){
-    //Materialized view addition
-
-    $sql_t2d = "select string_agg(DISTINCT(f1.name),E' ') AS domains, t.phylotree_id, string_agg(DISTINCT(d.iprterm),E' ') AS ipr
- FROM feature f1
- JOIN cvterm cvt1
- ON cvt1.cvterm_id = f1.type_id
- JOIN featureloc
- ON featureloc.feature_id = f1.feature_id
- JOIN feature f2
- ON featureloc.srcfeature_id = f2.feature_id
- JOIN cvterm cvt2
- ON cvt2.cvterm_id = f2.type_id
- JOIN phylonode n
- ON n.feature_id=f2.feature_id
- JOIN phylotree t
- ON n.phylotree_id=t.phylotree_id
- JOIN domain d
- ON d.feature_name=f1.name
- WHERE cvt1.name in ('protein_hmm_match', 'protein_match') AND 
- cvt2.name = 'polypeptide'
- GROUP BY t.phylotree_id";
-
-    $schema_t2d = array (
-        'table' => 'tree2domain',
-        'fields' => array (
-            'domains' => array (
-                'type' => 'text',
-                'not null' => false,
-            ),
-            'phylotree_id' => array (
-                'type' => 'int',
-                'not null' => 'FASLE',
-            ),
-            'ipr' => array (
-            'type' => 'text',
-            'not null' => false,
-            ),
-
-         ),
-         'indexes' => array (
-            't2d_indx0' => array (
-                0 => 'phylotree_id',
-            ),
-        ),
-    );
-    
-    $comment_t2d = t('This view is used to provide a helper table for mapping phylotrees to domains.
-                          The view is queried by the phylotree_count mview\'s sql so it needs to be created and populated before the population of phylotree_count mview.');
-
-    tripal_add_mview(
-        'tree2domain', // name of materialized view
-        'tripal_phylotree', // name of module submitting view
-        $schema_t2d,      // schema api array representation
-        $sql_t2d,         // sql query that loads the mview
-        $comment_t2d );
-   
-
-
-   $sql_query="WITH count_genes as (select count(*) count, t.phylotree_id from phylotree t, phylonode n where n.phylotree_id=t.phylotree_id and n.label is not null group by t.phylotree_id),
-count_medtr_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'medtr.%' group by t.phylotree_id),
-count_tripr_genes as (select count(fp.value) count, t.phylotree_id from phylotree t left outer join featureprop fp on fp.value=t.name inner join feature f on fp.feature_id=f.feature_id and f.name like 'tripr.%' group by t.phylotree_id),
-count_lotja_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'lotja.%' group by t.phylotree_id),
-count_cicar_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'cicar.%' group by t.phylotree_id),
-count_cajca_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'cajca.%' group by t.phylotree_id),
-count_vigun_genes as (select count(fp.value) count, t.phylotree_id from phylotree t left outer join featureprop fp on fp.value=t.name inner join feature f on fp.feature_id=f.feature_id and f.name like 'vigun.%' group by t.phylotree_id),
-count_vigra_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'vigra.%' group by t.phylotree_id),
-count_vigan_genes as (select count(fp.value) count, t.phylotree_id from phylotree t left outer join featureprop fp on fp.value=t.name inner join feature f on fp.feature_id=f.feature_id and f.name like 'vigan.%' group by t.phylotree_id),
-count_phavu_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'phavu.%' group by t.phylotree_id),
-count_aradu_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'aradu.%' group by t.phylotree_id),
-count_araip_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'araip.%' group by t.phylotree_id),
-count_lupan_genes as (select count(fp.value) count, t.phylotree_id from phylotree t left outer join featureprop fp on fp.value=t.name inner join feature f on fp.feature_id=f.feature_id and f.name like 'lupan.%' group by t.phylotree_id),
-count_glyma_genes as (select count(n.phylonode_id) count, t.phylotree_id from phylotree t left outer join phylonode n on n.phylotree_id=t.phylotree_id and n.label like 'glyma.%' group by t.phylotree_id),
-consensus2domain as (select string_agg(DISTINCT(f.name),E' ') domains_con ,string_agg(DISTINCT(d.iprterm),E' ') AS ipr2, phylotree_id from feature f JOIN cvterm cvt1 ON cvt1.cvterm_id=f.type_id JOIN featureloc floc ON f.feature_id=floc.feature_id JOIN feature f2 ON floc.srcfeature_id=f2.feature_id JOIN cvterm cvt2 ON cvt2.cvterm_id=f2.type_id JOIN phylotree ON f2.name = phylotree.name || '-consensus' JOIN domain d ON d.feature_name=f.name WHERE cvt2.name='consensus_region' and (cvt1.name='protein_match' OR cvt1.name='protein_hmm_match') group by phylotree.phylotree_id)
-SELECT 
-phylotree.phylotree_id AS phylotree_phylotree_id, 
-phylotree.name AS phylotree_name, 
-phylotree.comment AS phylotree_comment, 
-count_genes.count as total_count, 
-count_medtr_genes.count as medtr_count, 
-coalesce(count_tripr_genes.count,0) as tripr_count,
-count_lotja_genes.count as lotja_count, 
-count_cicar_genes.count as cicar_count, 
-count_glyma_genes.count as glyma_count, 
-count_phavu_genes.count as phavu_count, 
-count_cajca_genes.count as cajca_count, 
-coalesce(count_vigun_genes.count,0) as vigun_count,
-count_vigra_genes.count as vigra_count, 
-coalesce(count_vigan_genes.count,0) as vigan_count,
-count_aradu_genes.count as aradu_count, 
-count_araip_genes.count as araip_count,
-coalesce(count_lupan_genes.count,0) as lupan_count,
-c2d.domains_con || ' ' || coalesce(c2d.ipr2, '') as domains_con
-FROM chado.phylotree phylotree
-LEFT JOIN consensus2domain c2d ON phylotree.phylotree_id = c2d.phylotree_id
-LEFT JOIN chado_phylotree chado_phylotree ON phylotree.phylotree_id = chado_phylotree.phylotree_id
-LEFT JOIN count_genes count_genes ON phylotree.phylotree_id = count_genes.phylotree_id
-LEFT JOIN count_medtr_genes ON phylotree.phylotree_id = count_medtr_genes.phylotree_id
-LEFT JOIN count_tripr_genes ON phylotree.phylotree_id = count_tripr_genes.phylotree_id
-LEFT JOIN count_lotja_genes ON phylotree.phylotree_id = count_lotja_genes.phylotree_id
-LEFT JOIN count_cicar_genes ON phylotree.phylotree_id = count_cicar_genes.phylotree_id
-LEFT JOIN count_glyma_genes ON phylotree.phylotree_id = count_glyma_genes.phylotree_id
-LEFT JOIN count_phavu_genes ON phylotree.phylotree_id = count_phavu_genes.phylotree_id
-LEFT JOIN count_cajca_genes ON phylotree.phylotree_id = count_cajca_genes.phylotree_id
-LEFT JOIN count_vigun_genes ON phylotree.phylotree_id = count_vigun_genes.phylotree_id
-LEFT JOIN count_vigra_genes ON phylotree.phylotree_id = count_vigra_genes.phylotree_id
-LEFT JOIN count_vigan_genes ON phylotree.phylotree_id = count_vigan_genes.phylotree_id
-LEFT JOIN count_aradu_genes ON phylotree.phylotree_id = count_aradu_genes.phylotree_id
-LEFT JOIN count_araip_genes ON phylotree.phylotree_id = count_araip_genes.phylotree_id
-LEFT JOIN count_lupan_genes ON phylotree.phylotree_id = count_lupan_genes.phylotree_id
-JOIN analysis a ON phylotree.analysis_id=a.analysis_id JOIN analysisprop ap ON ap.analysis_id=a.analysis_id JOIN cvterm ct ON ap.type_id=ct.cvterm_id
-WHERE ct.name='is_current'";
-
-    //Table Phylotree User Search  description
-
-     $schema = array (
+  $schema = array (
     'table' => 'phylotree_count',
-     'fields' => array(
+    'fields' => array(
       'phylotree_phylotree_id' => array(
         'type' => 'int',
         'not null' => FALSE,
@@ -453,90 +211,39 @@ WHERE ct.name='is_current'";
       'phylotree_name' => array(
         'type' => 'text',
         'not null' => FALSE,
-      ),   
+      ),
       'phylotree_comment' => array(
         'type' => 'text',
         'not null' => FALSE,
       ),
       'total_count' => array(
         'type' => 'int',
-        'not null' => TRUE, 
-      ),
-      'medtr_count' => array(
-        'type' => 'int',
         'not null' => TRUE,
       ),
-      'tripr_count' => array(
-        'type' => 'int',
+      'counts_by_org' => array(
+        'type' => 'text',
         'not null' => TRUE,
       ),
-      'lotja_count' => array(
-        'type' => 'int',
-        'not null' => TRUE,
-      ),
-      'cicar_count' => array(
-        'type' => 'int',
-        'not null' => TRUE,
-      ),
-      'glyma_count' => array(
-        'type' => 'int',
-        'not null' => TRUE,
-      ),
-      'phavu_count' => array(
-          'type' => 'int',
-          'not null' => TRUE,
-      ),
-      'cajca_count' => array(
-          'type' => 'int',
-          'not null' => TRUE,
-      ),
-      'vigun_count' => array(
-          'type' => 'int',
-          'not null' => TRUE,
-      ),
-      'vigra_count' => array(
-          'type' => 'int',
-          'not null' => TRUE,
-      ),
-      'vigan_count' => array(
-          'type' => 'int',
-          'not null' => TRUE,
-      ),
-      'aradu_count' => array(
-          'type' => 'int',
-          'not null' => TRUE,
-      ),
-      'araip_count' => array(
-          'type' => 'int',
-          'not null' => TRUE,
-      ),
-      'lupan_count' => array(
-          'type' => 'int',
-          'not null' => TRUE,
-      ),
-
-     'domains_con' => array (
-          'type' => 'text',
-          'not null' => false,
-      ),
-
-
-
-
-
-   ),
-   'primary key' => array('phylotree_phylotree_id'),
-    'indexes' => array (
-        'phylotree_indx0' => array (
-            0 => 'phylotree_name',
-        ),
-        'phylotree_indx2' => array (
-            0 => 'domains_con',
-        ),
     ),
+    'primary key' => array('phylotree_phylotree_id'),
   );
 
-   // add a comment to make sure this view makes sense to the site administator
+  if ($with_domain) {
+    $schema['fields']['domains_con'] = array (
+        'type' => 'text',
+        'not null' => false,
+    );
+    $schema['indexes'] = array (
+      'phylotree_indx0' => array (
+        0 => 'phylotree_name',
+      ),
+      'phylotree_indx2' => array (
+        0 => 'domains_con',
+      ),
+    );
+  }
+
+  // add a comment to make sure this view makes sense to the site administator
   $comment = t('This view is used to provide a table for Phylotree User Search with total- and per species- counts.');
   tripal_add_mview(
     'phylotree_count', // name of materialized view
@@ -544,83 +251,141 @@ WHERE ct.name='is_current'";
     $schema,      // schema api array representation
     $sql_query,         // sql query that loads the mview
     $comment );
-  
+}
+
+
+function tripal_phylotree_add_tree2domain_mview() {
+  //Materialized view addition
+
+  $sql_t2d = "select string_agg(DISTINCT(f1.name),E' ') AS domains, t.phylotree_id, string_agg(DISTINCT(d.iprterm),E' ') AS ipr
+  FROM feature f1
+  JOIN cvterm cvt1
+  ON cvt1.cvterm_id = f1.type_id
+  JOIN featureloc
+  ON featureloc.feature_id = f1.feature_id
+  JOIN feature f2
+  ON featureloc.srcfeature_id = f2.feature_id
+  JOIN cvterm cvt2
+  ON cvt2.cvterm_id = f2.type_id
+  JOIN phylonode n
+  ON n.feature_id=f2.feature_id
+  JOIN phylotree t
+  ON n.phylotree_id=t.phylotree_id
+  JOIN domain d
+  ON d.feature_name=f1.name
+  WHERE cvt1.name in ('protein_hmm_match', 'protein_match') AND
+  cvt2.name = 'polypeptide'
+  GROUP BY t.phylotree_id";
+
+  $schema_t2d = array (
+    'table' => 'tree2domain',
+    'fields' => array (
+      'domains' => array (
+        'type' => 'text',
+        'not null' => false,
+      ),
+      'phylotree_id' => array (
+        'type' => 'int',
+        'not null' => 'FASLE',
+      ),
+      'ipr' => array (
+        'type' => 'text',
+        'not null' => false,
+      ),
+
+    ),
+    'indexes' => array (
+      't2d_indx0' => array (
+        0 => 'phylotree_id',
+      ),
+    ),
+  );
+
+  $comment_t2d = t('This view is used to provide a helper table for mapping phylotrees to domains.
+  The view is queried by the phylotree_count mview\'s sql so it needs to be created and populated before the population of phylotree_count mview.');
+
+  tripal_add_mview(
+    'tree2domain', // name of materialized view
+    'tripal_phylotree', // name of module submitting view
+    $schema_t2d,      // schema api array representation
+    $sql_t2d,         // sql query that loads the mview
+    $comment_t2d );
 }
 
 /**
- * Integrate the qtl_search materialized view for use by Drupal Views and
- * our search form
- */
+* Integrate the materialized view for use by Drupal Views and
+* our search form
+*/
 
-function tripal_phylotree_integrate_view(){
+function tripal_phylotree_integrate_view($with_domain = FALSE){
 
+  if ($with_domain) {
     $integration_t2d = array (
-        'table' => 'tree2domain',
-        'name' => 'tree2domain',
-        'type' => 'chado',
-        'description' => '',
-        'priority' => '-1',
-        'base_table' => '1',
-        'fields' => array (
-            'phylotree_id' => array (
-                'name' => 'phylotree_id',
-                'title' => 'phylotree_id',
-                'description' => 'Phylotree ID',
-                'type' => 'int',
-                'handlers' => array (
-                    'filter' => array (
-                        'name' => 'views_handler_filter_numeric',
-                    ),
-                    'field' => array (
-                        'name' => 'views_handler_field_numeric',
-                    ),
-                    'sort' => array (
-                        'name' => 'views_handler_sort',
-                    ),
-                    'argument' => array (
-                        'name' => 'views_handler_argument_numeric',
-                    ),
-                    'relationship' => array (
-                        'name' => 'views_handler_relationship',
-                    ),
-                ),
-                'joins' => array (
-                ),
+      'table' => 'tree2domain',
+      'name' => 'tree2domain',
+      'type' => 'chado',
+      'description' => '',
+      'priority' => '-1',
+      'base_table' => '1',
+      'fields' => array (
+        'phylotree_id' => array (
+          'name' => 'phylotree_id',
+          'title' => 'phylotree_id',
+          'description' => 'Phylotree ID',
+          'type' => 'int',
+          'handlers' => array (
+            'filter' => array (
+              'name' => 'views_handler_filter_numeric',
             ),
-            'domains' => array (
-                'name' => 'domains',
-                'title' => 'Domains',
-                'description' => 'Domains',
-                'type' => 'text',
-                'handlers' => array (
-                    'filter' => array (
-                        'name' => 'tripal_views_handler_filter_select_string',
-                    ),
-                    'field' => array (
-                        'name' => 'views_handler_field',
-                    ),
-                    'sort' => array (
-                        'name' => 'views_handler_sort',
-                    ),
-                    'argument' => array (
-                        'name' => 'views_handler_argument_string',
-                    ),
-                    'relationship' => array (
-                        'name' => 'views_handler_relationship',
-                    ),
-                ),
-                'joins' => array (
-                ),
+            'field' => array (
+              'name' => 'views_handler_field_numeric',
             ),
+            'sort' => array (
+              'name' => 'views_handler_sort',
+            ),
+            'argument' => array (
+              'name' => 'views_handler_argument_numeric',
+            ),
+            'relationship' => array (
+              'name' => 'views_handler_relationship',
+            ),
+          ),
+          'joins' => array (
+          ),
         ),
+        'domains' => array (
+          'name' => 'domains',
+          'title' => 'Domains',
+          'description' => 'Domains',
+          'type' => 'text',
+          'handlers' => array (
+            'filter' => array (
+              'name' => 'tripal_views_handler_filter_select_string',
+            ),
+            'field' => array (
+              'name' => 'views_handler_field',
+            ),
+            'sort' => array (
+              'name' => 'views_handler_sort',
+            ),
+            'argument' => array (
+              'name' => 'views_handler_argument_string',
+            ),
+            'relationship' => array (
+              'name' => 'views_handler_relationship',
+            ),
+          ),
+          'joins' => array (
+          ),
+        ),
+      ),
     );
-    // add the array above that will integrate our qtl_search materialized view
+    // add the array above that will integrate our materialized view
     // for use with Drupal Views
     tripal_add_views_integration($integration_t2d);
-   
+  }
 
- 
-    $integration = array (
+  $integration = array (
     'table' => 'phylotree_count',
     'name' => 'phylotree_count',
     'type' => 'chado',
@@ -629,479 +394,217 @@ function tripal_phylotree_integrate_view(){
     'base_table' => '1',
     'fields' => array (
       'phylotree_phylotree_id' => array (
-          'name' => 'phylotree_phylotree_id',
-          'title' => 'Phylotree ID',
-          'description' => 'Phylotree ID',
-          'type' => 'int',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'views_handler_filter_numeric',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field_numeric',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_numeric',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
+        'name' => 'phylotree_phylotree_id',
+        'title' => 'Phylotree ID',
+        'description' => 'Phylotree ID',
+        'type' => 'int',
+        'handlers' => array (
+          'filter' => array (
+            'name' => 'views_handler_filter_numeric',
           ),
-          'joins' => array (
+          'field' => array (
+            'name' => 'views_handler_field_numeric',
           ),
+          'sort' => array (
+            'name' => 'views_handler_sort',
+          ),
+          'argument' => array (
+            'name' => 'views_handler_argument_numeric',
+          ),
+          'relationship' => array (
+            'name' => 'views_handler_relationship',
+          ),
+        ),
+        'joins' => array (
+        ),
       ),
 
       'phylotree_name' => array (
-          'name' => 'phylotree_name',
-          'title' => 'Family ID',
-          'description' => 'Family ID',
-          'type' => 'text',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'tripal_views_handler_filter_select_string',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_string',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
+        'name' => 'phylotree_name',
+        'title' => 'Family ID',
+        'description' => 'Family ID',
+        'type' => 'text',
+        'handlers' => array (
+          'filter' => array (
+            'name' => 'tripal_views_handler_filter_select_string',
           ),
-          'joins' => array (
+          'field' => array (
+            'name' => 'views_handler_field',
           ),
+          'sort' => array (
+            'name' => 'views_handler_sort',
+          ),
+          'argument' => array (
+            'name' => 'views_handler_argument_string',
+          ),
+          'relationship' => array (
+            'name' => 'views_handler_relationship',
+          ),
+        ),
+        'joins' => array (
+        ),
       ),
 
       'phylotree_comment' => array (
-          'name' => 'phylotree_comment',
-          'title' => 'Description',
-          'description' => 'Description',
-          'type' => 'text',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'tripal_views_handler_filter_select_string',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_string',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
+        'name' => 'phylotree_comment',
+        'title' => 'Description',
+        'description' => 'Description',
+        'type' => 'text',
+        'handlers' => array (
+          'filter' => array (
+            'name' => 'tripal_views_handler_filter_select_string',
           ),
-          'joins' => array (
+          'field' => array (
+            'name' => 'views_handler_field',
           ),
+          'sort' => array (
+            'name' => 'views_handler_sort',
+          ),
+          'argument' => array (
+            'name' => 'views_handler_argument_string',
+          ),
+          'relationship' => array (
+            'name' => 'views_handler_relationship',
+          ),
+        ),
+        'joins' => array (
+        ),
       ),
- 
+
       'total_count' => array (
-          'name' => 'total_count',
-          'title' => 'Gene count',
-          'description' => 'Gene count',
-          'type' => 'int',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'views_handler_filter_numeric',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_numeric',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
+        'name' => 'total_count',
+        'title' => 'Total gene count',
+        'description' => 'Total gene count',
+        'type' => 'int',
+        'handlers' => array (
+          'filter' => array (
+            'name' => 'views_handler_filter_numeric',
           ),
-          'joins' => array (
+          'field' => array (
+            'name' => 'views_handler_field',
           ),
+          'sort' => array (
+            'name' => 'views_handler_sort',
+          ),
+          'argument' => array (
+            'name' => 'views_handler_argument_numeric',
+          ),
+          'relationship' => array (
+            'name' => 'views_handler_relationship',
+          ),
+        ),
+        'joins' => array (
+        ),
       ),
 
-      'medtr_count' => array (
-          'name' => 'medtr_count',
-          'title' => 'Medtr count',
-          'description' => 'Medtr count',
-          'type' => 'int',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'views_handler_filter_numeric',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_numeric',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
+      'counts_by_org' => array (
+        'name' => 'counts_by_org',
+        'title' => 'Counts by organisms',
+        'description' => 'Count by organims',
+        'type' => 'text',
+        'handlers' => array (
+          'filter' => array (
+            'name' => 'tripal_views_handler_filter_select_string',
           ),
-          'joins' => array (
+          'field' => array (
+            'name' => 'views_handler_field',
           ),
+          'sort' => array (
+            'name' => 'views_handler_sort',
+          ),
+          'argument' => array (
+            'name' => 'views_handler_argument_string',
+          ),
+          'relationship' => array (
+            'name' => 'views_handler_relationship',
+          ),
+        ),
+        'joins' => array (
+        ),
       ),
 
-      'tripr_count' => array (
-          'name' => 'tripr_count',
-          'title' => 'Tripr count',
-          'description' => 'Tripr count',
-          'type' => 'int',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'views_handler_filter_numeric',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_numeric',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
-          ),
-          'joins' => array (
-          ),
-      ),
+    ),
+  );
 
-      'lotja_count' => array (
-          'name' => 'lotja_count',
-          'title' => 'Lotja count',
-          'description' => 'Lotja count',
-          'type' => 'int',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'views_handler_filter_numeric',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_numeric',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
-          ),
-          'joins' => array (
-          ),
+  if ($with_domain) {
+    $integration['fields']['domains_con'] = array (
+      'name' => 'domains_con',
+      'title' => 'Domains_con',
+      'description' => 'Domains_con',
+      'type' => 'text',
+      'handlers' => array (
+        'filter' => array (
+          'name' => 'tripal_views_handler_filter_select_string',
+        ),
+        'field' => array (
+          'name' => 'views_handler_field',
+        ),
+        'sort' => array (
+          'name' => 'views_handler_sort',
+        ),
+        'argument' => array (
+          'name' => 'views_handler_argument_string',
+        ),
+        'relationship' => array (
+          'name' => 'views_handler_relationship',
+        ),
       ),
-
-      'cicar_count' => array (
-          'name' => 'cicar_count',
-          'title' => 'Cicar (CDCFrontier) count',
-          'description' => 'Cicar (CDCFrontier) count',
-          'type' => 'int',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'views_handler_filter_numeric',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_numeric',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
-          ),
-          'joins' => array (
-          ),
+      'joins' => array (
       ),
-
-      'glyma_count' => array (
-          'name' => 'glyma_count',
-          'title' => 'Glyma count',
-          'description' => 'Glyma count',
-          'type' => 'int',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'views_handler_filter_numeric',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_numeric',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
-          ),
-          'joins' => array (
-          ),
-      ),
-
-      'phavu_count' => array (
-          'name' => 'phavu_count',
-          'title' => 'Phavu count',
-          'description' => 'Phavu count',
-          'type' => 'int',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'views_handler_filter_numeric',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_numeric',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
-          ),
-          'joins' => array (
-          ),
-      ),
-
-      'cajca_count' => array (
-          'name' => 'cajca_count',
-          'title' => 'Cajca count',
-          'description' => 'Cajca count',
-          'type' => 'int',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'views_handler_filter_numeric',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_numeric',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
-          ),
-          'joins' => array (
-          ),
-      ),
-
-      'vigun_count' => array (
-          'name' => 'vigun_count',
-          'title' => 'Vigun count',
-          'description' => 'Vigun count',
-          'type' => 'int',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'views_handler_filter_numeric',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_numeric',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
-          ),
-          'joins' => array (
-          ),
-      ),
-
-      'vigra_count' => array (
-          'name' => 'vigra_count',
-          'title' => 'Vigra count',
-          'description' => 'Vigra count',
-          'type' => 'int',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'views_handler_filter_numeric',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_numeric',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
-          ),
-          'joins' => array (
-          ),
-      ),
-
-      'vigan_count' => array (
-          'name' => 'vigan_count',
-          'title' => 'Vigan count',
-          'description' => 'Vigan count',
-          'type' => 'int',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'views_handler_filter_numeric',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_numeric',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
-          ),
-          'joins' => array (
-          ),
-      ),
-
-      'aradu_count' => array (
-          'name' => 'aradu_count',
-          'title' => 'Aradu count',
-          'description' => 'Aradu count',
-          'type' => 'int',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'views_handler_filter_numeric',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_numeric',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
-          ),
-          'joins' => array (
-          ),
-      ),
-
-      'araip_count' => array (
-          'name' => 'araip_count',
-          'title' => 'Araip count',
-          'description' => 'Araip count',
-          'type' => 'int',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'views_handler_filter_numeric',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_numeric',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
-          ),
-          'joins' => array (
-          ),
-      ),
-      
-
-      'lupan_count' => array (
-          'name' => 'lupan_count',
-          'title' => 'Lupan count',
-          'description' => 'Lupan count',
-          'type' => 'int',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'views_handler_filter_numeric',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_numeric',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
-          ),
-          'joins' => array (
-          ),
-      ),
-      
-
-
-     'domains_con' => array (
-          'name' => 'domains_con',
-          'title' => 'Domains_con',
-          'description' => 'Domains_con',
-          'type' => 'text',
-          'handlers' => array (
-              'filter' => array (
-                  'name' => 'tripal_views_handler_filter_select_string',
-              ),
-              'field' => array (
-                  'name' => 'views_handler_field',
-              ),
-              'sort' => array (
-                  'name' => 'views_handler_sort',
-              ),
-              'argument' => array (
-                  'name' => 'views_handler_argument_string',
-              ),
-              'relationship' => array (
-                  'name' => 'views_handler_relationship',
-              ),
-          ),
-          'joins' => array (
-          ),
-      ),
-   ), 
     );
-// add the array above that will integrate our qtl_search materialized view
-    // for use with Drupal Views
-    tripal_add_views_integration($integration);
+  }
 
+  // add the array above that will integrate our materialized view
+  // for use with Drupal Views
+  tripal_add_views_integration($integration);
+}
+
+
+
+
+/**
+ * Adds controlled vocabulary terms needed by this module.
+ *
+ * @ingroup tripal_phylotree
+ */
+function tripal_phylotree_add_cvterms() {
+
+  tripal_insert_cv(
+    'tripal_phylotree',
+    'Terms used by the Tripal phylotree module for phylogenetic and taxonomic trees.'
+  );
+
+  // Add the terms used to identify nodes in the tree.
+  tripal_insert_cvterm(
+    array(
+      'name' => 'phylo_leaf',
+      'definition' => 'A leaf node in a phylogenetic tree.',
+      'cv_name' => 'tripal_phylotree',
+      'is_relationship' => 0,
+      'db_name' => 'tripal'
+    ),
+    array('update_existing' => TRUE)
+  );
+  // Add the terms used to identify nodes in the tree.
+  tripal_insert_cvterm(
+    array(
+      'name' => 'phylo_root',
+      'definition' => 'The root node of a phylogenetic tree.',
+      'cv_name' => 'tripal_phylotree',
+      'is_relationship' => 0,
+      'db_name' => 'tripal'
+    ),
+    array('update_existing' => TRUE)
+  );
+  // Add the terms used to identify nodes in the tree.
+  tripal_insert_cvterm(
+    array(
+      'name' => 'phylo_interior',
+      'definition' => 'An interior node in a phylogenetic tree.',
+      'cv_name' => 'tripal_phylotree',
+      'is_relationship' => 0,
+      'db_name' => 'tripal'
+    ),
+    array('update_existing' => TRUE)
+  );
 }

--- a/tripal_phylotree.module
+++ b/tripal_phylotree.module
@@ -119,7 +119,7 @@ function tripal_phylotree_menu() {
     'page arguments' => array(1),
     'access callback' => TRUE // allow all anonymous http clients
    );
-  
+
    // route for viewing json of all phylonodes having this phylotree_id
    $items['chado_phylotree/%/json'] = array(
     'page callback' => 'phylotree_json_endpoint',
@@ -133,7 +133,7 @@ function tripal_phylotree_menu() {
        'page arguments' => array(2),
        'access callback' => TRUE // allow all anonymous http requests
    );
-   
+
    return $items;
 }
 
@@ -192,7 +192,7 @@ function tripal_phylotree_theme($existing, $type, $theme, $path) {
       'base hook' => 'node',
       'path' => "$core_path/theme/templates",
     ),
-    // base template for this page (default tab) includes the phylogram 
+    // base template for this page (default tab) includes the phylogram
     'tripal_phylotree_base' => array(
       'variables' => array('node' => NULL),
       'template' => 'tripal_phylotree_base',
@@ -228,20 +228,29 @@ function tripal_phylotree_theme($existing, $type, $theme, $path) {
 * */
 
 function tripal_phylotree_form_alter(&$form, &$form_state, $form_id) {
-//drupal_set_message("Form ID is: $form_id"); ?~@~S uncomment to verify form name
-if ($form_id == 'views_exposed_form') { $form['#validate'][] = 'tripal_phylotree_form_validate';
-//drupal_set_message("Validation is set to " . var_export($form['#validate'], true)); -- uncomment to verify validator was added 
- }
+    //drupal_set_message("Form ID is: $form_id"); ?~@~S uncomment to verify form name
+    if ($form_id == 'views_exposed_form') {
+        $form['#validate'][] = 'tripal_phylotree_form_validate';
+        //drupal_set_message("Validation is set to " . var_export($form['#validate'], true)); -- uncomment to verify validator was added
+    }
 }
 /**
   * Form validator for search form.
   * Use this to trim whitespace from text fields.
   */
 function tripal_phylotree_form_validate($form, &$form_state) {
-//drupal_set_message("Form values are " . var_export($form_state['values'], true)); -- uncomment to see form field names 
-$form_state['values']['phylotree_name'] = trim($form_state['values']['phylotree_name']);
-$form_state['values']['phylotree_comment'] = trim($form_state['values']['phylotree_comment']);
-$form_state['values']['domains_con'] = trim($form_state['values']['domains_con']);
+    //drupal_set_message("Form values are " . var_export($form_state['values'], true)); -- uncomment to see form field names
+    if (isset($form_state['values']['phylotree_name'])) {
+        $form_state['values']['phylotree_name'] = trim($form_state['values']['phylotree_name']);
+    }
+
+    if (isset($form_state['values']['phylotree_comment'])) {
+        $form_state['values']['phylotree_comment'] = trim($form_state['values']['phylotree_comment']);
+    }
+
+    if (isset($form_state['values']['domains_con'])) {
+        $form_state['values']['domains_con'] = trim($form_state['values']['domains_con']);
+    }
 }
 
 


### PR DESCRIPTION
As promises in #23, here's a first PR with the changes I made on the drupal view displaying the number of gene per species. There were some hardcoded species name, now it's dynamic.

To do this, in the materialized view, for each tree I store a json listing of per species count, and then I parse it when displaying the drupal view. I have not seen performance problem with ~20000 trees.

I'm not sure if it's really mergeable as is because:
- but there is no more aggregation of gene number by genus as there was before. I don't see a good way to decide which species should be grouped together (maybe on the genus organism column?). If you have a suggestion don't hesitate
- I couldn't find a way to add the filters for each organism, I have some chunks of code on my HDD, but it's not working, and it's lower priority for me right now.

Anyway, feel free to test and make suggestions!

(Sorry for the delay, I had to work on python-chado to speed up the loading process. Loading gff using tripal was just too long when loading several genomes.)